### PR TITLE
Umożliwienie zdefiniowania mapowania projektów redmine -> toggl

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,9 @@ var toggl_api_key = 'x'; // DO UZUPEŁNIENIA
 var toggl_workspace_id = 1; // DO UZUPEŁNIENIA
 ```
 wartości można znaleźć w https://www.toggl.com/api/v8/me
+- opcjonalnie ustawić mapowanie projektów redmine &raquo; toggl (zmienna `projects`), np.
+```
+var projects = {
+	'MyProject': 12345
+};
+```

--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ Konfiguracja:
 var toggl_api_key = 'x'; // DO UZUPEŁNIENIA
 var toggl_workspace_id = 1; // DO UZUPEŁNIENIA
 ```
-- wartości można znaleźć w https://www.toggl.com/api/v8/me
+wartości można znaleźć w https://www.toggl.com/api/v8/me

--- a/redmine-toggl-button.user.js
+++ b/redmine-toggl-button.user.js
@@ -22,6 +22,11 @@ var toggl_api = 'https://www.toggl.com/api/v8/'
 var start_button_id='toggl-start';
 var start_input_id='toggl-comment';
 
+// mapowanie nazwy projektu z redmine na jego ID w toggl
+var projects = {
+  // do uzupełnienia
+};
+
 function changeButton() {
   $('#' + start_input_id).prop('disabled', true);
   $('#' + start_button_id).unbind( "click" ).click(function(e) {
@@ -39,6 +44,8 @@ function startEntry() {
   var now = new Date(); //without params it defaults to "now"
   var start_time = now.toJSON();
     
+  var project = $('.current-project').text();
+
   var start_request = 
     {
       "time_entry":
@@ -47,7 +54,8 @@ function startEntry() {
         "description":$('#' + start_input_id).val(),
         //"tags":[""],
         "wid":toggl_workspace_id,
-        "created_with":"RedmineTogglButton"
+        "created_with":"RedmineTogglButton",
+        "pid": projects[project]
       }
     };
   


### PR DESCRIPTION
Dzięki temu przy kliknięciu start od razu może ustawić nam się prawidłowy projekt